### PR TITLE
문자열 덧셈 계산기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 
 group = 'camp.nextstep'
 version = '1.0.0'
-sourceCompatibility = '1.8'
+sourceCompatibility = '11'
 
 repositories {
 	mavenCentral()

--- a/src/main/java/stringaddcalculator/Calculator.java
+++ b/src/main/java/stringaddcalculator/Calculator.java
@@ -1,0 +1,60 @@
+package stringaddcalculator;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class Calculator {
+
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("^[0-9]*$");
+    private static final Pattern CUSTOM_PATTERN = Pattern.compile("//(.*)\n(.*)");
+    private static final String DEFAULT_SEPARATOR = "[,:]";
+
+    public int calculate(String input) {
+        if (isEmpty(input)) {
+            return 0;
+        }
+
+        List<String> separateValues = separateValue(input);
+        return addNumber(mappingNumbers(separateValues));
+    }
+
+    private List<String> separateValue(String input) {
+        String value = input;
+        String separator = DEFAULT_SEPARATOR;
+
+        Matcher matcher = CUSTOM_PATTERN.matcher(input);
+        if (matcher.find()) {
+            String customDelimiter = matcher.group(1);
+            separator += ("|" + customDelimiter);
+            value = matcher.group(2);
+        }
+
+        return List.of(value.split(separator));
+    }
+
+    private Integer addNumber(List<Integer> numbers) {
+        return numbers.stream()
+                .reduce(0, Integer::sum);
+    }
+
+    private List<Integer> mappingNumbers(List<String> values) {
+        return values.stream()
+                .filter(value -> !value.equals(""))
+                .map(this::changeInt)
+                .collect(Collectors.toList());
+    }
+
+    private int changeInt(String value) {
+        if (!NUMBER_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("숫자가 아니거나 음수입니다");
+        }
+
+        return Integer.parseInt(value);
+    }
+
+    private boolean isEmpty(String text) {
+        return text == null || text.equals("");
+    }
+}

--- a/src/test/java/stringaddcalculator/CalculatorTest.java
+++ b/src/test/java/stringaddcalculator/CalculatorTest.java
@@ -1,0 +1,75 @@
+package stringaddcalculator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class CalculatorTest {
+
+    private Calculator calculator;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new Calculator();
+    }
+
+    @Test
+    @DisplayName("null 또는 빈문자 테스트")
+    void null_or_empty_test() {
+        assertAll(
+                () -> assertThat(calculator.calculate(null)).isEqualTo(0),
+                () -> assertThat(calculator.calculate("")).isEqualTo(0)
+        );
+    }
+
+    @Test
+    @DisplayName("숫자 하나 테스트")
+    void one_number_test() {
+        assertThat(calculator.calculate("1")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("구분자 쉼표 테스트")
+    void comma_separator_test() {
+        assertThat(calculator.calculate("1,2")).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("구분자 공백포함 테스트")
+    void comma_separator_include_empty_test() {
+        assertAll(
+                () -> assertThat(calculator.calculate("1,,")).isEqualTo(1),
+                () -> assertThat(calculator.calculate("1,,2")).isEqualTo(3)
+        );
+    }
+
+    @Test
+    @DisplayName("구분자 쉼표 콜론 테스트")
+    void comma_colon_separator_test() {
+        assertThat(calculator.calculate("1,2:3")).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("커스텀 구분자 테스트")
+    void custom_separator_test() {
+        assertAll(
+                () -> assertThat(calculator.calculate("//;\n1,2;3")).isEqualTo(6),
+                () -> assertThat(calculator.calculate("//-\n1,2-3")).isEqualTo(6)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-1,2,3", "a,2,3"})
+    @DisplayName("숫자가 아닌 예외 테스트")
+    void not_number_exception_test(String input) {
+        assertThatThrownBy(() -> calculator.calculate(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("숫자가 아니거나 음수입니다");
+    }
+}


### PR DESCRIPTION
### 기능 요구사항
- 쉼표(,) 또는 콜론(:)을 구분자로 가지는 문자열을 전달하는 경우 구분자를 기준으로 분리한 각 숫자의 합을 반환 (예: “” => 0, "1,2" => 3, "1,2,3" => 6, “1,2:3” => 6)
- 앞의 기본 구분자(쉼표, 콜론)외에 커스텀 구분자를 지정할 수 있다. 커스텀 구분자는 문자열 앞부분의 “//”와 “\n” 사이에 위치하는 문자를 커스텀 구분자로 사용한다. 예를 들어 “//;\n1;2;3”과 같이 값을 입력할 경우 커스텀 구분자는 세미콜론(;)이며, 결과 값은 6이 반환되어야 한다.
- 문자열 계산기에 숫자 이외의 값 또는 음수를 전달하는 경우 RuntimeException 예외를 throw한다.